### PR TITLE
Integrate trunk into bluescape-cli

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,7 @@
+*out
+*logs
+*actions
+*notifications
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/config/.markdownlint.yaml
+++ b/.trunk/config/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/config/.shellcheckrc
+++ b/.trunk/config/.shellcheckrc
@@ -1,0 +1,7 @@
+enable=all
+source-path=SCRIPTDIR
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,28 @@
+version: 0.1
+cli:
+  version: 1.0.1
+plugins:
+  sources:
+    - id: trunk
+      ref: v0.0.5
+      uri: https://github.com/trunk-io/plugins
+lint:
+  enabled:
+    - eslint@8.26.0
+    - git-diff-check
+    - markdownlint@0.32.2
+    - shellcheck@0.8.0
+    - shfmt@3.5.0
+    - actionlint@1.6.21
+    - gitleaks@8.15.0
+    - prettier@2.7.1
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+    - trunk-upgrade-available

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "bs": "build/cli.js"
       },
       "devDependencies": {
+        "@trunkio/launcher": "1.2.2",
         "@types/clear": "0.1.2",
         "@types/configstore": "5.0.1",
         "@types/inquirer": "8.2.1",
@@ -657,6 +658,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@trunkio/launcher": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@trunkio/launcher/-/launcher-1.2.2.tgz",
+      "integrity": "sha512-HHgrpW1QkfoORWnhlJhrGpsqtNCvHuNaoFVMLIhb7duay9Ra0k4tCzZ8eVjzd5n2aHMVzKQ0rZMmr0zrk2Rndw==",
+      "dev": true,
+      "bin": {
+        "trunk": "trunk"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -6131,6 +6141,12 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@trunkio/launcher": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@trunkio/launcher/-/launcher-1.2.2.tgz",
+      "integrity": "sha512-HHgrpW1QkfoORWnhlJhrGpsqtNCvHuNaoFVMLIhb7duay9Ra0k4tCzZ8eVjzd5n2aHMVzKQ0rZMmr0zrk2Rndw==",
+      "dev": true
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
     "bs": "npm run build && node ./build/cli.js",
     "package:linux": "pkg . --no-bytecode --targets node14-linux-x64 --output bin/linux/bluescape",
     "package:macos": "pkg . --no-bytecode --targets node14-macos-x64 --output bin/macos/bluescape",
-    "format": "prettier --write",
-    "format:check": "prettier --loglevel warn --check \"**/*.{ts,js,json,yaml}\"",
-      "lint": "eslint -c .eslintrc.js \"{src,test}/**/*.ts\" --fix",
-    "lint:check": "eslint \"src/**/*.ts\"",
-    "test": "npm run test "
+    "test": "npm run test ",
+    "trunk": "trunk",
+    "format": "trunk fmt",
+    "lint": "trunk check"
   },
   "main": "./build/cli.js",
   "bin": {
@@ -54,6 +53,7 @@
     "@types/yargs": "17.0.10",
     "@typescript-eslint/eslint-plugin": "5.25.0",
     "@typescript-eslint/parser": "5.25.0",
+    "@trunkio/launcher": "1.2.2",
     "babel-eslint": "10.1.0",
     "eslint": "8.15.0",
     "eslint-config-prettier": "8.5.0",


### PR DESCRIPTION
Hi all,

Wanted to provide an example pull request that integrates trunk [https://docs.trunk.io] into this repository. Trunk is a universal meta linter that manages discovery, execution and management of all the open source tooling you should be running on your repositories. 

You can get a sense of what running this tool feels like on your repo. `trunk` is completely git aware so it only runs on files as you change them and has a bunch of other cool bells and whistles.

```
npm run trunk check --  --sample=5
```

Some examples of output I found:
![image](https://user-images.githubusercontent.com/1265982/198112103-ab7f8acb-b1f5-4929-8c02-eb4106ee7b5e.png)


![image](https://user-images.githubusercontent.com/1265982/198112022-5b2d92c9-903f-4a26-afbb-e89166395758.png)
